### PR TITLE
Updated expressGraphQL to graphqlHTTP

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 const express = require('express')
-const expressGraphQL = require('express-graphql')
+const { graphqlHTTP } = require('express-graphql')
 const {
   GraphQLSchema,
   GraphQLObjectType,
@@ -128,7 +128,7 @@ const schema = new GraphQLSchema({
   mutation: RootMutationType
 })
 
-app.use('/graphql', expressGraphQL({
+app.use('/graphql', graphqlHTTP({
   schema: schema,
   graphiql: true
 }))


### PR DESCRIPTION
**Before :**
`const expressGraphQL = require("express-graphql");`
---
**After :**
`const { graphqlHTTP } = require("express-graphql");`
---
## This is the correct way, as described in the documentation.
#### `const expressGraphQL` gave errors

